### PR TITLE
cleanup game servers and always recreate creds

### DIFF
--- a/setup/masterserver.sh
+++ b/setup/masterserver.sh
@@ -34,14 +34,18 @@ else
 	su pwn3 -c "psql master -f $PWN3/initdb.sql"
 	su pwn3 -c "psql master -f $PWN3/setup/postgres_master.sql"
 	su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-admin-team Admin"
-	
-	# get the master server creds
-	su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-server-account > /opt/pwn3/server/creds"
+fi
 
-	# write the creds to the server.ini
-	USER=$(cat /opt/pwn3/server/creds | grep 'Username:' | cut -d ":" -f 2- | xargs)
-	PW=$(cat /opt/pwn3/server/creds | grep 'Password:' | cut -d ":" -f 2- | xargs)
-	cat >/opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Content/Server/server.ini <<EOL
+# cleanup all previous/old server master creds
+su pwn3 -c "psql master -f $PWN3/setup/postgres_cleanup.sql"
+
+# get new master server creds
+su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-server-account > /opt/pwn3/server/creds"
+
+# write the new creds to the server.ini
+USER=$(cat /opt/pwn3/server/creds | grep 'Username:' | cut -d ":" -f 2- | xargs)
+PW=$(cat /opt/pwn3/server/creds | grep 'Password:' | cut -d ":" -f 2- | xargs)
+cat >/opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Content/Server/server.ini <<EOL
 [MasterServer]
 Hostname=master.pwn3
 Port=3333
@@ -53,8 +57,6 @@ Username=$USER
 Password=$PW
 Instances=5
 EOL
-fi
-
 
 
 # run the server

--- a/setup/postgres_cleanup.sql
+++ b/setup/postgres_cleanup.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS tempToCleanUp (
+  userId int NOT NULL,
+  teamId int NOT NULL
+);
+
+DELETE FROM tempToCleanUp;
+
+INSERT INTO tempToCleanUp
+SELECT u.id, u.team
+FROM public.users u
+WHERE u.name LIKE 'server_%'
+	and u.user_type = 2;
+
+DELETE FROM public.users u
+WHERE u.id IN (SELECT userId FROM tempToCleanUp);
+
+DELETE FROM public.teams t
+WHERE t.id IN (SELECT teamId FROM tempToCleanUp)
+AND t.name LIKE 'server_%';
+
+DROP TABLE IF EXISTS tempToCleanUp;


### PR DESCRIPTION
Always remove game servers from the team and users tables and recreate a new one on each restart of the master server.
resolves #3 