### PR TITLE
Update for fresh debian install

### DIFF
--- a/setup/gameserver.sh
+++ b/setup/gameserver.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-su pwn3 -c "cd /opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Binaries/Linux/ && ./PwnAdventure3Server"
+# it only ran as root for me 
+su root -c "cd /opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Binaries/Linux/ && ./PwnAdventure3Server"

--- a/setup/masterserver.sh
+++ b/setup/masterserver.sh
@@ -22,7 +22,7 @@ sleep 10
 su postgres -c "psql -f $PWN3/setup/postgres_init.sql -d template1"
 
 # clean up
-su pwn3 -c "rm /opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Saved/Logs/*"
+su root -c "rm /opt/pwn3/client/PwnAdventure3_Data/PwnAdventure3/PwnAdventure3/Saved/Logs/*"
 
 if [ -f /opt/pwn3/postgres-data/data.sql ]; then
     echo "Found data, making a backup now!"
@@ -36,8 +36,10 @@ else
 	su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-admin-team Admin"
 	
 	# get the master server creds
-	su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-server-account > /opt/pwn3/server/creds"
-
+	CREDS=$(su pwn3 -c "cd /opt/pwn3/server/MasterServer/ && ./MasterServer --create-server-account > /tmp/out.tmp")
+	# use root to access the directory
+	su root -c "cat /tmp/out.tmp > /opt/pwn3/server/creds"
+	
 	# write the creds to the server.ini
 	USER=$(cat /opt/pwn3/server/creds | grep 'Username:' | cut -d ":" -f 2- | xargs)
 	PW=$(cat /opt/pwn3/server/creds | grep 'Password:' | cut -d ":" -f 2- | xargs)


### PR DESCRIPTION
If `docker-compose` is installed correctly, then the following setup should correct the failure in the startup of the game server. Simply run `docker-compose` under sudo to give the file permissions to edit the `/opt` directory.